### PR TITLE
Add redirect for onboarding start

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,7 @@ a progress bar and persists data in MySQL.
 
 ## Usage
 
-Navigate to `onboarding/step1.php` to start. Progress is saved through
-sessions and written to the `seller_onboarding` table.
+Visit the `onboarding/` directory (or your site's root URL) to begin.
+The included `index.php` will automatically redirect you to the first
+step of the onboarding flow. Progress is saved through sessions and
+written to the `seller_onboarding` table.

--- a/onboarding/index.php
+++ b/onboarding/index.php
@@ -1,0 +1,5 @@
+<?php
+// Redirect to the first step of the onboarding flow
+header('Location: step1.php');
+exit();
+?>


### PR DESCRIPTION
## Summary
- automatically kick off onboarding when the site is opened
- document that index.php starts the onboarding flow

## Testing
- `php -l onboarding/index.php`

------
https://chatgpt.com/codex/tasks/task_e_68750f20d128832092cea2162df76a4e